### PR TITLE
Language, canceled/reject statuses, logging of gateway responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /bin/
 /vendor/
 composer.lock
+/nbproject/private/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 /bin/
 /vendor/
-composer.lock
-/nbproject/private/

--- a/Action/CaptureAction.php
+++ b/Action/CaptureAction.php
@@ -15,8 +15,7 @@ use Payum\Core\Request\Capture;
 use Payum\Core\Security\GenericTokenFactory;
 
 /**
- * Class CaptureAction
- * @package Accesto\Component\Payum\PayU\Action
+ * Class CaptureAction.
  */
 class CaptureAction extends GatewayAwareAction implements ActionInterface
 {
@@ -38,7 +37,7 @@ class CaptureAction extends GatewayAwareAction implements ActionInterface
     /**
      * @param mixed $request
      *
-     * @return boolean
+     * @return bool
      */
     public function supports($request)
     {

--- a/Action/ConvertPaymentAction.php
+++ b/Action/ConvertPaymentAction.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Accesto\Component\Payum\PayU\Action;
 
 use Accesto\Component\Payum\PayU\Model\Product;
@@ -10,13 +11,12 @@ use Payum\Core\Model\PaymentInterface;
 use Payum\Core\Request\Convert;
 
 /**
- * Class ConvertPaymentAction
- * @package Accesto\Component\Payum\PayU\Action
+ * Class ConvertPaymentAction.
  */
 class ConvertPaymentAction extends GatewayAwareAction
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
      * @param Convert $request
      */
@@ -25,7 +25,7 @@ class ConvertPaymentAction extends GatewayAwareAction
         RequestNotSupportedException::assertSupports($this, $request);
 
         /**
-         * @var $order PaymentInterface
+         * @var PaymentInterface
          */
         $order = $request->getSource();
         $details = ArrayObject::ensureArrayObject($order->getDetails());
@@ -43,14 +43,13 @@ class ConvertPaymentAction extends GatewayAwareAction
             'lastName' => isset($d['lastName']) ? $d['lastName'] : '',
             'language' => $order->getLocale() ? substr($order->getLocale(), 0, 2) : '',
         );
-        $details['status']  = 'NEW';
+        $details['status'] = 'NEW';
 
         $request->setResult((array) $details);
     }
 
-
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function supports($request)
     {

--- a/Action/ConvertPaymentAction.php
+++ b/Action/ConvertPaymentAction.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Accesto\Component\Payum\PayU\Action;
 
 use Accesto\Component\Payum\PayU\Model\Product;
@@ -11,12 +10,13 @@ use Payum\Core\Model\PaymentInterface;
 use Payum\Core\Request\Convert;
 
 /**
- * Class ConvertPaymentAction.
+ * Class ConvertPaymentAction
+ * @package Accesto\Component\Payum\PayU\Action
  */
 class ConvertPaymentAction extends GatewayAwareAction
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @param Convert $request
      */
@@ -25,7 +25,7 @@ class ConvertPaymentAction extends GatewayAwareAction
         RequestNotSupportedException::assertSupports($this, $request);
 
         /**
-         * @var PaymentInterface
+         * @var $order PaymentInterface
          */
         $order = $request->getSource();
         $details = ArrayObject::ensureArrayObject($order->getDetails());
@@ -43,13 +43,23 @@ class ConvertPaymentAction extends GatewayAwareAction
             'lastName' => isset($d['lastName']) ? $d['lastName'] : '',
             'language' => $order->getLocale() ? substr($order->getLocale(), 0, 2) : '',
         );
-        $details['status'] = 'NEW';
+        $details['status']  = 'NEW';
+
+        $details['settings'] = array(
+            'invoiceDisabled' => true
+        );
+
+        if ($order->getPaymentForm() == 'card') {
+            $details['payMethods'] = array(
+                'payMethod' => ['type' => 'PBL', 'value' => 'c']
+            );
+        }
 
         $request->setResult((array) $details);
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function supports($request)
     {

--- a/Action/ConvertPaymentAction.php
+++ b/Action/ConvertPaymentAction.php
@@ -41,6 +41,7 @@ class ConvertPaymentAction extends GatewayAwareAction
             'email' => $order->getClientEmail(),
             'firstName' => isset($d['firstName']) ? $d['firstName'] : '',
             'lastName' => isset($d['lastName']) ? $d['lastName'] : '',
+            'language' => $order->getLocale() ? substr($order->getLocale(), 0, 2) : '',
         );
         $details['status']  = 'NEW';
 

--- a/Action/NotifyAction.php
+++ b/Action/NotifyAction.php
@@ -12,12 +12,10 @@ use Payum\Core\Request\Notify;
 use Payum\Core\Request\Sync;
 
 /**
- * Class NotifyAction
- * @package Accesto\Component\Payum\PayU\Action
+ * Class NotifyAction.
  */
 class NotifyAction extends GatewayAwareAction implements ActionInterface
 {
-
     /**
      * @param mixed $request
      *
@@ -25,19 +23,18 @@ class NotifyAction extends GatewayAwareAction implements ActionInterface
      */
     public function execute($request)
     {
-        /** @var $request Notify */
+        /* @var $request Notify */
         RequestNotSupportedException::assertSupports($this, $request);
         $setPayU = new SetPayU($request->getToken());
-        $setPayU->setModel($request->getModel());;
+        $setPayU->setModel($request->getModel());
         $this->gateway->execute($setPayU);
         $status = new GetHumanStatus($request->getToken());
         $status->setModel($request->getModel());
         $this->gateway->execute($status);
     }
 
-
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function supports($request)
     {

--- a/Action/SetPayUAction.php
+++ b/Action/SetPayUAction.php
@@ -18,7 +18,8 @@ use Payum\Core\Security\GenericTokenFactoryAwareInterface;
 use Payum\Core\Security\GenericTokenFactoryInterface;
 
 /**
- * Class SetPayUAction.
+ * Class SetPayUAction
+ * @package Accesto\Component\Payum\PayU\Action
  */
 class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenFactoryAwareInterface
 {
@@ -36,6 +37,8 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
 
     /**
      * @param GenericTokenFactoryInterface $genericTokenFactory
+     *
+     * @return void
      */
     public function setGenericTokenFactory(GenericTokenFactoryInterface $genericTokenFactory = null)
     {
@@ -57,7 +60,7 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function execute($request)
     {
@@ -70,8 +73,8 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
 
         $model = $request->getModel();
         $model = ArrayObject::ensureArrayObject($model);
-        /*
-         * @var Token
+        /**
+         * @var Token $token
          */
         $token = $request->getToken();
 
@@ -87,14 +90,19 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
             $order['totalAmount'] = $model['totalAmount'];
             $order['extOrderId'] = $model['extOrderId']; //must be unique!
             $order['buyer'] = $model['buyer'];
+            $order['settings'] = $model['settings'];
+
+            if ($model['payMethods']) {
+                $order['payMethods'] = $model['payMethods'];
+            }
 
             if (!array_key_exists('products', $model) || count($model['products']) == 0) {
                 $order['products'] = array(
                     array(
                         'name' => $model['description'],
                         'unitPrice' => $model['totalAmount'],
-                        'quantity' => 1,
-                    ),
+                        'quantity' => 1
+                    )
                 );
             } else {
                 $order['products'] = $model['products'];
@@ -120,10 +128,11 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
                 $request->setModel($model);
             }
         }
+
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function supports($request)
     {

--- a/Action/SetPayUAction.php
+++ b/Action/SetPayUAction.php
@@ -18,8 +18,7 @@ use Payum\Core\Security\GenericTokenFactoryAwareInterface;
 use Payum\Core\Security\GenericTokenFactoryInterface;
 
 /**
- * Class SetPayUAction
- * @package Accesto\Component\Payum\PayU\Action
+ * Class SetPayUAction.
  */
 class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenFactoryAwareInterface
 {
@@ -28,8 +27,8 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
      */
     protected $tokenFactory;
 
-    protected $api = array();   
-   
+    protected $api = array();
+
     /**
      * @var OpenPayUWrapper
      */
@@ -37,8 +36,6 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
 
     /**
      * @param GenericTokenFactoryInterface $genericTokenFactory
-     *
-     * @return void
      */
     public function setGenericTokenFactory(GenericTokenFactoryInterface $genericTokenFactory = null)
     {
@@ -60,24 +57,24 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function execute($request)
-    {        
+    {
         RequestNotSupportedException::assertSupports($this, $request);
         $environment = $this->api['environment'];
         $signature = $this->api['signature_key'];
-        $posId = $this->api['pos_id'];        
-        
+        $posId = $this->api['pos_id'];
+
         $openPayU = $this->getOpenPayUWrapper() ? $this->getOpenPayUWrapper() : new OpenPayUWrapper($environment, $signature, $posId);
 
         $model = $request->getModel();
         $model = ArrayObject::ensureArrayObject($model);
-        /**
-         * @var Token $token
+        /*
+         * @var Token
          */
-        $token = $request->getToken();       
-        
+        $token = $request->getToken();
+
         if ($model['orderId'] == null) {
             $order = array();
             $order['continueUrl'] = $token->getTargetUrl(); //customer will be redirected to this page after successfull payment
@@ -89,23 +86,23 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
             $order['currencyCode'] = $model['currencyCode'];
             $order['totalAmount'] = $model['totalAmount'];
             $order['extOrderId'] = $model['extOrderId']; //must be unique!
-            $order['buyer'] = $model['buyer'];            
+            $order['buyer'] = $model['buyer'];
 
             if (!array_key_exists('products', $model) || count($model['products']) == 0) {
                 $order['products'] = array(
                     array(
                         'name' => $model['description'],
                         'unitPrice' => $model['totalAmount'],
-                        'quantity' => 1
-                    )
+                        'quantity' => 1,
+                    ),
                 );
             } else {
                 $order['products'] = $model['products'];
             }
 
-            $response = $openPayU->create($order)->getResponse();           
+            $response = $openPayU->create($order)->getResponse();
             $model['payUResponse'] = $response;
-            
+
             if ($response && $response->status->statusCode == 'SUCCESS') {
                 $model['orderId'] = $response->orderId;
                 $request->setModel($model);
@@ -116,18 +113,17 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
             }
         } else {
             $response = $openPayU->retrieve($model['orderId'])->getResponse();
-            $model['payUResponse'] = $response;      
-            
+            $model['payUResponse'] = $response;
+
             if ($response->status->statusCode == 'SUCCESS') {
                 $model['status'] = $response->orders[0]->status;
                 $request->setModel($model);
             }
         }
-
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function supports($request)
     {
@@ -150,5 +146,5 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
     public function setOpenPayUWrapper($openPayUWrapper)
     {
         $this->openPayUWrapper = $openPayUWrapper;
-    }    
+    }
 }

--- a/Action/SetPayUAction.php
+++ b/Action/SetPayUAction.php
@@ -28,8 +28,8 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
      */
     protected $tokenFactory;
 
-    protected $api = array();
-
+    protected $api = array();   
+   
     /**
      * @var OpenPayUWrapper
      */
@@ -63,12 +63,12 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
      * {@inheritDoc}
      */
     public function execute($request)
-    {
+    {        
         RequestNotSupportedException::assertSupports($this, $request);
         $environment = $this->api['environment'];
         $signature = $this->api['signature_key'];
-        $posId = $this->api['pos_id'];
-
+        $posId = $this->api['pos_id'];        
+        
         $openPayU = $this->getOpenPayUWrapper() ? $this->getOpenPayUWrapper() : new OpenPayUWrapper($environment, $signature, $posId);
 
         $model = $request->getModel();
@@ -76,7 +76,8 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
         /**
          * @var Token $token
          */
-        $token = $request->getToken();
+        $token = $request->getToken();       
+        
         if ($model['orderId'] == null) {
             $order = array();
             $order['continueUrl'] = $token->getTargetUrl(); //customer will be redirected to this page after successfull payment
@@ -88,7 +89,7 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
             $order['currencyCode'] = $model['currencyCode'];
             $order['totalAmount'] = $model['totalAmount'];
             $order['extOrderId'] = $model['extOrderId']; //must be unique!
-            $order['buyer'] = $model['buyer'];
+            $order['buyer'] = $model['buyer'];            
 
             if (!array_key_exists('products', $model) || count($model['products']) == 0) {
                 $order['products'] = array(
@@ -102,8 +103,9 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
                 $order['products'] = $model['products'];
             }
 
-            $response = $openPayU->create($order)->getResponse();
-
+            $response = $openPayU->create($order)->getResponse();           
+            $model['payUResponse'] = $response;
+            
             if ($response && $response->status->statusCode == 'SUCCESS') {
                 $model['orderId'] = $response->orderId;
                 $request->setModel($model);
@@ -114,6 +116,8 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
             }
         } else {
             $response = $openPayU->retrieve($model['orderId'])->getResponse();
+            $model['payUResponse'] = $response;      
+            
             if ($response->status->statusCode == 'SUCCESS') {
                 $model['status'] = $response->orders[0]->status;
                 $request->setModel($model);
@@ -146,5 +150,5 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
     public function setOpenPayUWrapper($openPayUWrapper)
     {
         $this->openPayUWrapper = $openPayUWrapper;
-    }
+    }    
 }

--- a/Action/StatusAction.php
+++ b/Action/StatusAction.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Accesto\Component\Payum\PayU\Action;
 
 use Payum\Core\Action\ActionInterface;
@@ -9,44 +10,47 @@ use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Offline\Constants;
 
 /**
- * Class StatusAction
- * @package Accesto\Component\Payum\PayU\Action
+ * Class StatusAction.
  */
 class StatusAction implements ActionInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function execute($request)
     {
-        /** @var $request GetStatusInterface */
+        /* @var $request GetStatusInterface */
         RequestNotSupportedException::assertSupports($this, $request);
 
         $model = ArrayObject::ensureArrayObject($request->getModel());
 
         if (null === $model['status'] || 'NEW' == $model['status']) {
             $request->markNew();
+
             return;
         } elseif ($model['status'] == 'PENDING') {
             $request->markPending();
+
             return;
         } elseif ($model['status'] == 'COMPLETED') {
             $request->markCaptured();
+
             return;
         } elseif ($model['status'] == 'CANCELED') {
             $request->markCanceled();
-            return;    
-        }
-         elseif ($model['status'] == 'REJECTED') {
+
+            return;
+        } elseif ($model['status'] == 'REJECTED') {
             $request->markFailed();
-            return;    
+
+            return;
         }
 
         $request->markUnknown();
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function supports($request)
     {

--- a/Action/StatusAction.php
+++ b/Action/StatusAction.php
@@ -33,6 +33,13 @@ class StatusAction implements ActionInterface
         } elseif ($model['status'] == 'COMPLETED') {
             $request->markCaptured();
             return;
+        } elseif ($model['status'] == 'CANCELED') {
+            $request->markCanceled();
+            return;    
+        }
+         elseif ($model['status'] == 'REJECTED') {
+            $request->markFailed();
+            return;    
         }
 
         $request->markUnknown();


### PR DESCRIPTION
List of changes:
- language parameter to rest api (in order to be possible to set user language)
  - canceled, reject statuses (were absent though exist in PayU documentation)
  - adding clean response to model array in order to log all responses from payu via listner
    Example:
- in services

app.event_listener.payu_log_listener:
        class: PayULogListener  
        tags:
            - { name: kernel.event_listener, event: payum.gateway.post_execute, method: logResponse } 

class PayULogListener
........
    {  
        public function logResponse(ExecuteEvent $event)
        {
            if ($request instanceof \Accesto\Component\Payum\PayU\SetPayU) {  
                $model = ArrayObject::ensureArrayObject($request->getModel());
                //here you can log responses from payu gateway
                 dump($model['payUResponse']);die();
            }
        }
    }
