### PR TITLE
change continue url to token after url

### DIFF
--- a/Action/NotifyAction.php
+++ b/Action/NotifyAction.php
@@ -44,7 +44,7 @@ class NotifyAction extends GatewayAwareAction implements ActionInterface
             $request->setModel($refundPayU->getModel());
         } else {
             $setPayU = new SetPayU($request->getToken());
-	    $model = $request->getModel();
+            $model = $request->getModel();
             $model['orderId'] = $content['order']['orderId'] ?? null;
             $setPayU->setModel($model);
 
@@ -55,7 +55,7 @@ class NotifyAction extends GatewayAwareAction implements ActionInterface
         $status->setModel($request->getFirstModel());
         $status->setModel($request->getModel());
         $this->gateway->execute($status);
-    
+
         throw new HttpResponse('OK', 200);
     }
 
@@ -67,7 +67,6 @@ class NotifyAction extends GatewayAwareAction implements ActionInterface
     {
         return
             $request instanceof Notify &&
-            $request->getModel() instanceof \ArrayObject
-            ;
+            $request->getModel() instanceof \ArrayObject;
     }
 }

--- a/Action/NotifyAction.php
+++ b/Action/NotifyAction.php
@@ -44,7 +44,9 @@ class NotifyAction extends GatewayAwareAction implements ActionInterface
             $request->setModel($refundPayU->getModel());
         } else {
             $setPayU = new SetPayU($request->getToken());
-            $setPayU->setModel($request->getModel());
+	    $model = $request->getModel();
+            $model['orderId'] = $content['order']['orderId'] ?? null;
+            $setPayU->setModel($model);
 
             $this->gateway->execute($setPayU);
         }

--- a/Action/SetPayUAction.php
+++ b/Action/SetPayUAction.php
@@ -210,7 +210,7 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
      */
     private function setUrls($token, $order)
     {
-        $order['continueUrl'] = $token->getTargetUrl(); //customer will be redirected to this page after successfull payment
+        $order['continueUrl'] = $token->getAfterUrl() ?: $token->getTargetUrl(); //customer will be redirected to this page after successfull payment
         $order['notifyUrl'] = $this->tokenFactory->createNotifyToken($token->getGatewayName(),
             $token->getDetails())->getTargetUrl();
 


### PR DESCRIPTION
Looks like wrong url was used previously, it was redirecting to target url instead after url generated from after path provided in createCaptureToken method