### PR TITLE
resolve error at php 8 and payum/payum-bundle 1.5.2 

### DIFF
--- a/Action/SetPayUAction.php
+++ b/Action/SetPayUAction.php
@@ -190,8 +190,8 @@ class SetPayUAction implements ApiAwareInterface, ActionInterface, GenericTokenF
         if ($model instanceof ArrayObject) {
             $model = $model->getArrayCopy();
         }
-    	  
-        if (!array_key_exists('products', $model) || count($model['products']) == 0) {
+
+        if (!isset($model['products']) || count($model['products']) == 0) {
             $order['products'] = array(
                 array(
                     'name' => $model['description'],


### PR DESCRIPTION
resolve error at php 8 and payum/payum-bundle 1.5.2 -> php: CRITICAL:…Uncaught Error: array_key_exists(): Argument #2 () must be of type array, Payum\Core\Bridge\Spl\ArrayObject given